### PR TITLE
Fix java.lang.IllegalAccessError

### DIFF
--- a/library/src/main/java/com/leerybit/escpos/PosPrinter.java
+++ b/library/src/main/java/com/leerybit/escpos/PosPrinter.java
@@ -27,7 +27,7 @@ import com.leerybit.escpos.bluetooth.SearchPrinterDialog;
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-abstract class PosPrinter implements Printer {
+public abstract class PosPrinter implements Printer {
   private final Activity activity;
 
   private final BTService btService;


### PR DESCRIPTION
85ed14e27c16d854e1e7b6989d1b520e1dd09958 introduced a problem (at least) for me, that would crash the application with the below error message.

Adding `public` to the abstract PosPrinter class seems to solve the problem however. :-)

`E/AndroidRuntime: FATAL EXCEPTION: main
    Process: io.github.iyaroslav.posprinter, PID: 31625
    java.lang.IllegalStateException: Could not execute method for android:onClick
        at android.support.v7.app.AppCompatViewInflater$DeclaredOnClickListener.onClick(AppCompatViewInflater.java:390)
        at android.view.View.performClick(View.java:6935)
        at android.widget.TextView.performClick(TextView.java:12752)
        at android.view.View$PerformClick.run(View.java:26211)
        at android.os.Handler.handleCallback(Handler.java:790)
        at android.os.Handler.dispatchMessage(Handler.java:99)
        at android.os.Looper.loop(Looper.java:164)
        at android.app.ActivityThread.main(ActivityThread.java:7000)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:441)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1408)
     Caused by: java.lang.reflect.InvocationTargetException
        at java.lang.reflect.Method.invoke(Native Method)
        at android.support.v7.app.AppCompatViewInflater$DeclaredOnClickListener.onClick(AppCompatViewInflater.java:385)
        at android.view.View.performClick(View.java:6935) 
        at android.widget.TextView.performClick(TextView.java:12752) 
        at android.view.View$PerformClick.run(View.java:26211) 
        at android.os.Handler.handleCallback(Handler.java:790) 
        at android.os.Handler.dispatchMessage(Handler.java:99) 
        at android.os.Looper.loop(Looper.java:164) 
        at android.app.ActivityThread.main(ActivityThread.java:7000) 
        at java.lang.reflect.Method.invoke(Native Method) 
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:441) 
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1408) 
     Caused by: java.lang.IllegalAccessError: Illegal class access: 'io.github.iyaroslav.posprinter.MainActivity' attempting to access 'com.leerybit.escpos.PosPrinter' (declaration of 'io.github.iyaroslav.posprinter.MainActivity' appears in /data/app/io.github.iyaroslav.posprinter-eUwMIMOoQjf5BNqYTCe_PA==/base.apk)
        at io.github.iyaroslav.posprinter.MainActivity.printRawTicket(MainActivity.kt:98)
        at io.github.iyaroslav.posprinter.MainActivity.handleButtonClick(MainActivity.kt:88)
        at java.lang.reflect.Method.invoke(Native Method) 
        at android.support.v7.app.AppCompatViewInflater$DeclaredOnClickListener.onClick(AppCompatViewInflater.java:385) 
        at android.view.View.performClick(View.java:6935) 
        at android.widget.TextView.performClick(TextView.java:12752) 
        at android.view.View$PerformClick.run(View.java:26211) 
        at android.os.Handler.handleCallback(Handler.java:790) 
        at android.os.Handler.dispatchMessage(Handler.java:99) 
        at android.os.Looper.loop(Looper.java:164) 
        at android.app.ActivityThread.main(ActivityThread.java:7000) 
        at java.lang.reflect.Method.invoke(Native Method) 
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:441) 
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1408) 
`